### PR TITLE
fix: add quotes to default paths

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -30,7 +30,7 @@ class Format extends Component {
     }
 
     runPrettier () {
-        const { pattern = 'src/**/*.js' } = this.props;
+        const { pattern = `'src/**/*.js'` } = this.props;
         const format = exec(`npx prettier ${pattern} --write`, { async: true, silent: true });
 
         exec(`npx eslint ${pattern} --fix`, { async: true, silent: true }, () => {

--- a/src/lint.js
+++ b/src/lint.js
@@ -28,7 +28,7 @@ class Lint extends Component {
     }
 
     runEslint () {
-        const { pattern = 'src/**/*.js' } = this.props;
+        const { pattern = `'src/**/*.js'` } = this.props;
         const lint = exec(`npx eslint ${pattern} --fix`, { async: true, silent: true }, () => {
             this.setState({ status: '[done] Code linted' });
             setTimeout(() => {


### PR DESCRIPTION
This change ensures correct wildcard expansion in bash for default paths when running `dw format` and `dw lint`.