### PR TITLE
feat: sort package.json keys before writing

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,11 @@
+{
+    "plugins": [
+        [
+            "transform-react-jsx",
+            {
+                "pragma": "h",
+                "pragmaFrag": "h.Fragment"
+            }
+        ]
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@datawrapper/cli",
-  "version": "0.2.3",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@datawrapper/cli",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,27 +14,74 @@
       }
     },
     "@babel/core": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.2.2.tgz",
-      "integrity": "sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.3.4.tgz",
+      "integrity": "sha512-jRsuseXBo9pN197KnDwhhaaBzyZr2oIcLHHTt2oDdQrej5Qp57dCCJafWx5ivU8/alEYDpssYqv1MUqcxwQlrA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.2.2",
+        "@babel/generator": "^7.3.4",
         "@babel/helpers": "^7.2.0",
-        "@babel/parser": "^7.2.2",
+        "@babel/parser": "^7.3.4",
         "@babel/template": "^7.2.2",
-        "@babel/traverse": "^7.2.2",
-        "@babel/types": "^7.2.2",
+        "@babel/traverse": "^7.3.4",
+        "@babel/types": "^7.3.4",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.11",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
       },
       "dependencies": {
+        "@babel/generator": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
+          "integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.3.4",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
+          "integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
+          "integrity": "sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.3.4",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.0.0",
+            "@babel/parser": "^7.3.4",
+            "@babel/types": "^7.3.4",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.11"
+          }
+        },
+        "@babel/types": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
+          "integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "json5": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
@@ -276,14 +323,27 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.2.0.tgz",
-      "integrity": "sha512-Fr07N+ea0dMcMN8nFpuK6dUIT7/ivt9yKQdEEnjVS83tG2pHwPi03gYmk/tyuwONnZ+sY+GFFPlWGgCtW1hF9A==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.3.1.tgz",
+      "integrity": "sha512-Q82R3jKsVpUV99mgX50gOPCWwco9Ec5Iln/8Vyu4osNIOQgSrd9RFrQeUvmvddFNoLwMyOUWU+5ckioEKpDoGA==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.1.2",
         "@babel/traverse": "^7.1.5",
-        "@babel/types": "^7.2.0"
+        "@babel/types": "^7.3.0"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
+          "integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/highlight": {
@@ -5673,9 +5733,9 @@
       }
     },
     "lint-staged": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.1.3.tgz",
-      "integrity": "sha512-6TGkikL1B+6mIOuSNq2TV6oP21IhPMnV8q0cf9oYZ296ArTVNcbFh1l1pfVOHHbBIYLlziWNsQ2q45/ffmJ4AA==",
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.1.4.tgz",
+      "integrity": "sha512-oFbbhB/VzN8B3i/sIdb9gMfngGArI6jIfxSn+WPdQb2Ni3GJeS6T4j5VriSbQfxfMuYoQlMHOoFt+lfcWV0HfA==",
       "dev": true,
       "requires": {
         "@iamstarkov/listr-update-renderer": "0.4.1",
@@ -5691,7 +5751,7 @@
         "is-glob": "^4.0.0",
         "is-windows": "^1.0.2",
         "listr": "^0.14.2",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.11",
         "log-symbols": "^2.2.0",
         "micromatch": "^3.1.8",
         "npm-which": "^3.0.1",
@@ -8672,9 +8732,9 @@
       }
     },
     "static-eval": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.0.tgz",
-      "integrity": "sha512-6flshd3F1Gwm+Ksxq463LtFd1liC77N/PX1FVVc3OzL3hAmo2fwHFbuArkcfi7s9rTNsLEhcRmXGFZhlgy40uw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
       "dev": true,
       "requires": {
         "escodegen": "^1.8.1"

--- a/package.json
+++ b/package.json
@@ -77,15 +77,15 @@
     },
     "homepage": "https://github.com/datawrapper/cli#readme",
     "devDependencies": {
-        "@babel/core": "~7.2.2",
-        "babel-eslint": "^10.0.1",
+        "@babel/core": "~7.3.4",
+        "babel-eslint": "~10.0.1",
         "babel-plugin-transform-react-jsx": "~6.24.1",
-        "healthier": "^2.0.0",
-        "husky": "^1.3.1",
-        "lint-staged": "^8.1.3",
+        "healthier": "~2.0.0",
+        "husky": "~1.3.1",
+        "lint-staged": "~8.1.4",
         "parcel-bundler": "~1.11.0",
         "parcel-plugin-shebang": "~1.2.3",
-        "prettier": "^1.16.4"
+        "prettier": "~1.16.4"
     },
     "dependencies": {
         "commander": "2.19.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         }
     },
     "name": "@datawrapper/cli",
-    "version": "0.2.3",
+    "version": "0.2.2",
     "description": "Command Line Utility to make project scaffolding and tooling setup simple.",
     "main": "bin/index.js",
     "bin": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         }
     },
     "name": "@datawrapper/cli",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "description": "Command Line Utility to make project scaffolding and tooling setup simple.",
     "main": "bin/index.js",
     "bin": {

--- a/src/setup.js
+++ b/src/setup.js
@@ -287,5 +287,5 @@ function sortPackageJson(pkgJson) {
         .forEach(key => {
             sortedPackageJSON[key] = pkgJson[key];
         });
-    return pkgJson;
+    return sortedPackageJSON;
 }

--- a/src/setup.js
+++ b/src/setup.js
@@ -148,7 +148,11 @@ class Setup extends Component {
                 return mergeWith(newKeys, tempPackageJson, replaceSource);
             }, packageJson);
 
-        await fs.writeJSON(path.join(process.cwd(), 'package.json'), newPackageJson, { spaces: 2 });
+        const sortedPackageJson = sortPackageJson(newPackageJson);
+
+        await fs.writeJSON(path.join(process.cwd(), 'package.json'), sortedPackageJson, {
+            spaces: 4
+        });
 
         this.updateJob(jobIndex, 'Keys added to package.json');
         return ['  - package.json updated'];
@@ -239,3 +243,49 @@ class Setup extends Component {
 }
 
 module.exports = () => render(<Setup />);
+
+/**
+ * re-orders the keys in a package.json object
+ */
+function sortPackageJson(pkgJson) {
+    const keyOrder = [
+        'name',
+        'version',
+        'description',
+        'keywords',
+        'homepage',
+        'bugs',
+        'license',
+        'author',
+        'contributors',
+        'files',
+        'main',
+        'browser',
+        'bin',
+        'scripts',
+        'repository',
+        'config',
+        'directories',
+        'dependencies',
+        'devDependencies',
+        'peerDependencies',
+        'bundledDependencies',
+        'optionalDependencies'
+    ];
+    // create a temporary map to reduce computing overhead in sort function
+    const sortIndex = Object.keys(pkgJson).reduce((sortIndex, key) => {
+        sortIndex[key] = keyOrder.indexOf(key);
+        if (sortIndex[key] < 0) sortIndex[key] = 999;
+        return sortIndex;
+    }, {});
+
+    const sortedPackageJSON = {};
+    Object.keys(pkgJson)
+        .sort((a, b) => {
+            return sortIndex[a] - sortIndex[b];
+        })
+        .forEach(key => {
+            sortedPackageJSON[key] = pkgJson[key];
+        });
+    return pkgJson;
+}


### PR DESCRIPTION
I got annoyed by the key order in package.json's written by the cli, so I fixed this "bug" in this PR. I based the key order roughly on the order on [this page](https://docs.npmjs.com/files/package.json). keys that are not part of the `keyOrder` array will be moved to the end.